### PR TITLE
[BCHK-276] Se cambia statusCode de SSLHandshakeException

### DIFF
--- a/README-SSL-PINNING.md
+++ b/README-SSL-PINNING.md
@@ -19,7 +19,7 @@
 | -1 | Could not decode response data due to malformed data | MalformedInputException |
 | -1 | There was an error generating the response | JSONException |
 | -1 | There was an error with the request: + ex.getMessage() | HttpRequestException (Generic) |
-| **-2** | **SSL handshake failed** | **SSLHandshakeException** |
+| **-3** | **SSL handshake failed** | **SSLHandshakeException** |
 | **-2** | **Bad SSL key** | **SSLKeyException** |
 | **-2** | **Peer's identity has not been verified** | **SSLPeerUnverifiedException** |
 | **-2** | **Error in the operation of the SSL protocol** | **SSLProtocolException** |
@@ -51,7 +51,7 @@
 | -1 | The connection failed because a call is active. | -1019 kCFURLErrorCallIsActive |
 | -1 | The connection failed because data use is currently not allowed on the device. | -1020 kCFURLErrorDataNotAllowed |
 | -1 | The connection failed because its request’s body stream was exhausted. | -1021 kCFURLErrorRequestBodyStreamExhausted |
-| **-2** | **The connection was cancelled.** | **-999 NSURLErrorCancelled** |
+| **-3** | **The connection was cancelled.** | **-999 NSURLErrorCancelled** |
 
 ## Testing & Simulating MITM
 

--- a/src/android/com/synconset/cordovahttp/CordovaHttp.java
+++ b/src/android/com/synconset/cordovahttp/CordovaHttp.java
@@ -277,7 +277,7 @@ abstract class CordovaHttp {
       } else if (e.getCause() instanceof SocketTimeoutException) {
           this.respondWithError(1, "The request timed out");
       } else if (e.getCause() instanceof SSLHandshakeException) {
-          this.respondWithError(-2, "SSL handshake failed");
+          this.respondWithError(-3, "SSL handshake failed");
       } else if (e.getCause() instanceof SSLKeyException) {
         this.respondWithError(-2, "Bad SSL key");
       } else if (e.getCause() instanceof SSLPeerUnverifiedException) {

--- a/src/ios/CordovaHttpPlugin.m
+++ b/src/ios/CordovaHttpPlugin.m
@@ -93,7 +93,7 @@
     switch ([error code]) {
         case -999:
             // connection cancelled
-            return [NSNumber numberWithInt:-2];
+            return [NSNumber numberWithInt:-3];
         case -1001:
             // timeout
             return [NSNumber numberWithInt:1];


### PR DESCRIPTION
Se recibe incidente en donde se acusa de falso positivo en la comprobación pinning, acusando red insegura cuando la conexión a la red se encuentra inestable.

Se realiza cambio en el statusCode error SSLHandshakeException para realizar control del falso positivo y entregar información mas precisa al usuario.